### PR TITLE
ci: testing maven-build workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,11 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout PR branch (pushable)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
         with:
-          # Attach to the branch (not just a SHA) so we can push on 'push' runs
-          ref: ${{ github.ref_name }}           # e.g. "master" on push
-          fetch-depth: 0                        # good practice for diff/commit ops
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}   # <-- branch name on the fork
+          fetch-depth: 0
+          persist-credentials: true
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Why

Ensure project can compile and execute before submitting changes. 

## What

Added maven-build workflow to check that the submitted code actually compiles. This workflow also generates/edits `PROJECT_INFO/source-tree.txt` file which provides an overview of project structure.

## How

I took a simple Maven Java CI template and altered it a bit. I used ChatGPT to help configure some of the jobs in the workflow.

## Safety

- [ ] Tests added/updated
- [ ] Docs updated (README/inline/migrations)
- [x] No secrets/keys committed

## Links

- Issue: none
- Screenshots: none

## Review

- [x] Ready for review
- [ ] Risky area? If yes, ensure 2 reviewers
